### PR TITLE
Add default Firebase placeholder options

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,76 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      case TargetPlatform.windows:
+        return windows;
+      case TargetPlatform.linux:
+        return linux;
+      default:
+        return web;
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'demo-api-key-web',
+    appId: '1:000000000000:web:demoapp',
+    messagingSenderId: '000000000000',
+    projectId: 'senioren-app-demo',
+    authDomain: 'senioren-app-demo.firebaseapp.com',
+    storageBucket: 'senioren-app-demo.appspot.com',
+    measurementId: 'G-DEMO12345',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'demo-api-key-android',
+    appId: '1:000000000000:android:demoapp',
+    messagingSenderId: '000000000000',
+    projectId: 'senioren-app-demo',
+    storageBucket: 'senioren-app-demo.appspot.com',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'demo-api-key-ios',
+    appId: '1:000000000000:ios:demoapp',
+    messagingSenderId: '000000000000',
+    projectId: 'senioren-app-demo',
+    storageBucket: 'senioren-app-demo.appspot.com',
+    iosBundleId: 'com.example.seniorenApp',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'demo-api-key-macos',
+    appId: '1:000000000000:macos:demoapp',
+    messagingSenderId: '000000000000',
+    projectId: 'senioren-app-demo',
+    storageBucket: 'senioren-app-demo.appspot.com',
+    iosBundleId: 'com.example.seniorenApp',
+  );
+
+  static const FirebaseOptions windows = FirebaseOptions(
+    apiKey: 'demo-api-key-windows',
+    appId: '1:000000000000:windows:demoapp',
+    messagingSenderId: '000000000000',
+    projectId: 'senioren-app-demo',
+    storageBucket: 'senioren-app-demo.appspot.com',
+  );
+
+  static const FirebaseOptions linux = FirebaseOptions(
+    apiKey: 'demo-api-key-linux',
+    appId: '1:000000000000:linux:demoapp',
+    messagingSenderId: '000000000000',
+    projectId: 'senioren-app-demo',
+    storageBucket: 'senioren-app-demo.appspot.com',
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,11 +3,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'firebase_options.dart';
 import 'services/firebase_initializer.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
+
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  }
+
   await initializeFirebaseDependencies();
+
   runApp(const ProviderScope(child: SeniorenApp()));
 }


### PR DESCRIPTION
## Übersicht
- Füge plattformspezifische FirebaseOptions mit Demo-Werten hinzu, damit der Web-Start ohne echte Schlüssel funktioniert.
- Initialisiere Firebase in `main.dart` über die neuen Optionen, bevor abhängige Dienste geladen werden.

## Wie starten
- flutter pub get
- flutter run -d chrome

------
https://chatgpt.com/codex/tasks/task_e_68e3ab65442483278b2a7b9e65b5cbd7